### PR TITLE
Fix Users icon naming conflict in role selectors

### DIFF
--- a/client/components/users/ModernRolesSelector.tsx
+++ b/client/components/users/ModernRolesSelector.tsx
@@ -27,7 +27,7 @@ import {
   X,
   Shield,
   Crown,
-  Users,
+  Users as UsersIcon,
   Building,
   Code,
   TrendingUp,

--- a/client/components/users/ModernRolesSelector.tsx
+++ b/client/components/users/ModernRolesSelector.tsx
@@ -223,7 +223,7 @@ export const ModernRolesSelector: React.FC<ModernRolesSelectorProps> = ({
         "budget.view",
         "performance.review",
       ],
-      icon: Users,
+      icon: UsersIcon,
       color: "purple",
     },
     {

--- a/client/components/users/ModernRolesSelector.tsx
+++ b/client/components/users/ModernRolesSelector.tsx
@@ -107,7 +107,7 @@ export const ModernRolesSelector: React.FC<ModernRolesSelectorProps> = ({
       name: "Team Manager",
       description: "Team leadership with reporting access",
       roles: ["manager", "team_lead", "reports_viewer", "user_management"],
-      icon: Users,
+      icon: UsersIcon,
       color: "from-purple-400 to-purple-600",
       useCase: "For team leads and middle management",
     },

--- a/client/components/users/ModernRolesSelector.tsx
+++ b/client/components/users/ModernRolesSelector.tsx
@@ -283,7 +283,7 @@ export const ModernRolesSelector: React.FC<ModernRolesSelectorProps> = ({
         "roles.assign",
         "groups.manage",
       ],
-      icon: Users,
+      icon: UsersIcon,
       color: "red",
     },
     {

--- a/client/components/users/ModernRolesSelector.tsx
+++ b/client/components/users/ModernRolesSelector.tsx
@@ -721,7 +721,10 @@ export const ModernRolesSelector: React.FC<ModernRolesSelectorProps> = ({
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {/* Category Dropdown */}
                 <div>
-                  <Label htmlFor="category-select" className="text-sm font-medium">
+                  <Label
+                    htmlFor="category-select"
+                    className="text-sm font-medium"
+                  >
                     Category
                   </Label>
                   <Select
@@ -774,7 +777,8 @@ export const ModernRolesSelector: React.FC<ModernRolesSelectorProps> = ({
                 <div className="flex items-center space-x-2">
                   {selectedCategory !== "all" && (
                     <Badge variant="outline" className="text-xs">
-                      Category: {categories.find(c => c.id === selectedCategory)?.name}
+                      Category:{" "}
+                      {categories.find((c) => c.id === selectedCategory)?.name}
                       <X
                         className="ml-1 h-3 w-3 cursor-pointer"
                         onClick={() => setSelectedCategory("all")}
@@ -783,7 +787,7 @@ export const ModernRolesSelector: React.FC<ModernRolesSelectorProps> = ({
                   )}
                   {selectedLevel !== "all" && (
                     <Badge variant="outline" className="text-xs">
-                      Level: {levels.find(l => l.id === selectedLevel)?.name}
+                      Level: {levels.find((l) => l.id === selectedLevel)?.name}
                       <X
                         className="ml-1 h-3 w-3 cursor-pointer"
                         onClick={() => setSelectedLevel("all")}
@@ -802,7 +806,8 @@ export const ModernRolesSelector: React.FC<ModernRolesSelectorProps> = ({
                 </div>
                 <div className="flex items-center space-x-2">
                   <span className="text-sm text-gray-500">
-                    {filteredRoles.length} role{filteredRoles.length !== 1 ? 's' : ''} found
+                    {filteredRoles.length} role
+                    {filteredRoles.length !== 1 ? "s" : ""} found
                   </span>
                   <Button
                     variant="outline"
@@ -812,7 +817,11 @@ export const ModernRolesSelector: React.FC<ModernRolesSelectorProps> = ({
                       setSelectedCategory("all");
                       setSelectedLevel("all");
                     }}
-                    disabled={searchTerm === "" && selectedCategory === "all" && selectedLevel === "all"}
+                    disabled={
+                      searchTerm === "" &&
+                      selectedCategory === "all" &&
+                      selectedLevel === "all"
+                    }
                   >
                     <RotateCcw className="h-4 w-4" />
                   </Button>

--- a/client/components/users/ModernRolesSelector.tsx
+++ b/client/components/users/ModernRolesSelector.tsx
@@ -691,43 +691,72 @@ export const ModernRolesSelector: React.FC<ModernRolesSelectorProps> = ({
 
         {/* Individual Roles Tab */}
         <TabsContent value="individual" className="space-y-4">
-          {/* Search and Filters */}
+          {/* Enhanced Filters Section */}
           <Card>
-            <CardContent className="p-4">
-              <div className="flex flex-col md:flex-row gap-4">
-                <div className="flex-1">
-                  <div className="relative">
-                    <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-                    <Input
-                      placeholder="Search roles by name or description..."
-                      className="pl-10"
-                      value={searchTerm}
-                      onChange={(e) => setSearchTerm(e.target.value)}
-                    />
-                  </div>
+            <CardHeader>
+              <CardTitle className="flex items-center text-base">
+                <Filter className="mr-2 h-4 w-4" />
+                Filter Roles
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-4 space-y-4">
+              {/* Search */}
+              <div>
+                <Label htmlFor="search-roles" className="text-sm font-medium">
+                  Search Roles
+                </Label>
+                <div className="relative mt-1">
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                  <Input
+                    id="search-roles"
+                    placeholder="Search roles by name or description..."
+                    className="pl-10"
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                  />
                 </div>
-                <div className="flex gap-2">
+              </div>
+
+              {/* Category and Level Filters */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {/* Category Dropdown */}
+                <div>
+                  <Label htmlFor="category-select" className="text-sm font-medium">
+                    Category
+                  </Label>
                   <Select
                     value={selectedCategory}
                     onValueChange={setSelectedCategory}
                   >
-                    <SelectTrigger className="w-40">
-                      <SelectValue placeholder="Category" />
+                    <SelectTrigger className="w-full mt-1" id="category-select">
+                      <SelectValue placeholder="Select category..." />
                     </SelectTrigger>
                     <SelectContent>
                       {categories.map((category) => (
                         <SelectItem key={category.id} value={category.id}>
-                          {category.name} ({category.count})
+                          <div className="flex items-center justify-between w-full">
+                            <span>{category.name}</span>
+                            <Badge variant="secondary" className="ml-2 text-xs">
+                              {category.count}
+                            </Badge>
+                          </div>
                         </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
+                </div>
+
+                {/* Level Dropdown */}
+                <div>
+                  <Label htmlFor="level-select" className="text-sm font-medium">
+                    Access Level
+                  </Label>
                   <Select
                     value={selectedLevel}
                     onValueChange={setSelectedLevel}
                   >
-                    <SelectTrigger className="w-32">
-                      <SelectValue placeholder="Level" />
+                    <SelectTrigger className="w-full mt-1" id="level-select">
+                      <SelectValue placeholder="Select level..." />
                     </SelectTrigger>
                     <SelectContent>
                       {levels.map((level) => (
@@ -737,6 +766,44 @@ export const ModernRolesSelector: React.FC<ModernRolesSelectorProps> = ({
                       ))}
                     </SelectContent>
                   </Select>
+                </div>
+              </div>
+
+              {/* Active Filters & Results */}
+              <div className="flex items-center justify-between pt-2">
+                <div className="flex items-center space-x-2">
+                  {selectedCategory !== "all" && (
+                    <Badge variant="outline" className="text-xs">
+                      Category: {categories.find(c => c.id === selectedCategory)?.name}
+                      <X
+                        className="ml-1 h-3 w-3 cursor-pointer"
+                        onClick={() => setSelectedCategory("all")}
+                      />
+                    </Badge>
+                  )}
+                  {selectedLevel !== "all" && (
+                    <Badge variant="outline" className="text-xs">
+                      Level: {levels.find(l => l.id === selectedLevel)?.name}
+                      <X
+                        className="ml-1 h-3 w-3 cursor-pointer"
+                        onClick={() => setSelectedLevel("all")}
+                      />
+                    </Badge>
+                  )}
+                  {searchTerm && (
+                    <Badge variant="outline" className="text-xs">
+                      Search: "{searchTerm}"
+                      <X
+                        className="ml-1 h-3 w-3 cursor-pointer"
+                        onClick={() => setSearchTerm("")}
+                      />
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex items-center space-x-2">
+                  <span className="text-sm text-gray-500">
+                    {filteredRoles.length} role{filteredRoles.length !== 1 ? 's' : ''} found
+                  </span>
                   <Button
                     variant="outline"
                     size="sm"
@@ -745,6 +812,7 @@ export const ModernRolesSelector: React.FC<ModernRolesSelectorProps> = ({
                       setSelectedCategory("all");
                       setSelectedLevel("all");
                     }}
+                    disabled={searchTerm === "" && selectedCategory === "all" && selectedLevel === "all"}
                   >
                     <RotateCcw className="h-4 w-4" />
                   </Button>

--- a/client/pages/Users.tsx
+++ b/client/pages/Users.tsx
@@ -1357,7 +1357,7 @@ const EnhancedRolesSelector: React.FC<{
     {
       id: "hr",
       name: "Human Resources",
-      icon: Users,
+      icon: UsersIcon,
       count: allRoles.filter((r) => r.category === "hr").length,
     },
     {

--- a/client/pages/Users.tsx
+++ b/client/pages/Users.tsx
@@ -60,7 +60,7 @@ import {
   ChevronRight,
   X,
   Check,
-  Users,
+  Users as UsersIcon,
   Building,
   Tag,
   Star,


### PR DESCRIPTION
## Purpose

Fix a naming conflict with the `Users` icon import that was causing display issues in the User Management's Add User functionality, specifically in the Roles & Access section. The conflict occurred because the same `Users` identifier was being used for both the icon import and potentially other components.

## Code changes

- **Icon import aliasing**: Renamed `Users` import to `UsersIcon` in both `ModernRolesSelector.tsx` and `Users.tsx` to avoid naming conflicts
- **Icon references updated**: Updated all references from `icon: Users` to `icon: UsersIcon` across role definitions and category configurations
- **Enhanced filter UI**: Improved the roles filter section with better layout, labels, active filter badges, and result counts
- **Accessibility improvements**: Added proper labels and IDs for form controls in the filter section

The main fix resolves the icon naming conflict while the additional UI enhancements improve the overall user experience in role selection.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/54f3652cccd64bd3967e834122cd2c3d/nova-landing)

👀 [Preview Link](https://54f3652cccd64bd3967e834122cd2c3d-nova-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>54f3652cccd64bd3967e834122cd2c3d</projectId>-->
<!--<branchName>nova-landing</branchName>-->